### PR TITLE
Replaced click listeners with navigation in the header

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -9,11 +9,11 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarRecipeBookContent" [ngbCollapse]="!isNavbarCollapsed">
             <ul class="navbar-nav">
-                <li class="nav-item">
-                    <a class="nav-link" href="#" (click)="onSelect('recipe')">Recipes</a>
+                <li class="nav-item" routerLinkActive="active">
+                    <a class="nav-link" [routerLink]="['/recipes']">Recipes</a>
                 </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="#" (click)="onSelect('shopping-list')">Shopping List</a>
+                <li class="nav-item" routerLinkActive="active">
+                    <a class="nav-link" [routerLink]="['/shopping-list']">Shopping List</a>
                 </li>
             </ul>
             <ul class="navbar-nav ml-auto">

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, EventEmitter, Output } from '@angular/core';
+import { Component } from '@angular/core';
 
 @Component({
     selector: 'app-header',
@@ -6,14 +6,5 @@ import { Component, OnInit, EventEmitter, Output } from '@angular/core';
     styleUrls: ['./header.component.css']
 })
 
-export class HeaderComponent implements OnInit {
-    @Output() featureSelected = new EventEmitter<string>();
-
-    constructor() { }
-
-    ngOnInit() { }
-
-    onSelect(feature: string) {
-        this.featureSelected.emit(feature);
-    }
+export class HeaderComponent {
 }


### PR DESCRIPTION
Recipes and Shopping List now use navigation instead of event binding and the active route is displayed.